### PR TITLE
Update Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,14 @@ env:
     - WP_VERSION=*
 
 php:
+  - 7.3
   - 7.2
   - 7.1
-  - 7.0
   - 5.6
 
 matrix:
   include:
-    - php: 7.2
+    - php: 7.3
       env: WP_VERSION=4.4.0
     - php: 5.6
       env: WP_VERSION=4.4.0

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A complete example for using WP PHPUnit in the context of plugin development.
 **Travis CI Configuration**
 
 A ready to use `.travis.yml` configured with a reasonable test matrix
-- Includes all currently supported major versions of PHP (5.6, 7.0, 7.1, 7.2)
+- Includes all currently supported versions of PHP (7.1, 7.2, 7.3) and the current WP minimum required PHP 5.6
 - Tests against the latest version of WordPress, as well as an older version (4.4.0) although it could be easily extended to include multiple older versions, multisite, etc.
 
 **Just Add Tests**


### PR DESCRIPTION
- Add PHP 7.3
- Remove PHP 7.0 (EOL)

PHP 5.6 is EOL but kept as the last version in 5.x series, and the current minimum requirement for WP.