### PR TITLE
Update WP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,8 @@ before_script:
 
 install:
   - composer validate --strict
+  - composer require --no-update --dev roots/wordpress:${WP_VERSION} wp-phpunit/wp-phpunit:${WP_VERSION}
   - composer install
-  - composer require --dev --update-with-dependencies roots/wordpress:${WP_VERSION} wp-phpunit/wp-phpunit:${WP_VERSION}
   - composer show
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
 install:
   - composer validate --strict
   - composer install
-  - composer require --dev --update-with-dependencies johnpbloch/wordpress:${WP_VERSION} wp-phpunit/wp-phpunit:${WP_VERSION}
+  - composer require --dev --update-with-dependencies roots/wordpress:${WP_VERSION} wp-phpunit/wp-phpunit:${WP_VERSION}
   - composer show
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0",
-        "johnpbloch/wordpress": "4.9.*",
-        "wp-phpunit/wp-phpunit": "4.9.*"
+        "roots/wordpress": "^5.0",
+        "wp-phpunit/wp-phpunit": "^5.0"
     },
     "scripts": {
         "test": "phpunit"


### PR DESCRIPTION
Updates WP to use latest 5.x, and tweaks the build to be a little more efficient during the install.

WP package is also updated to use [`roots/wordpress`](https://roots.io/announcing-the-roots-wordpress-composer-package/).