### PR TITLE
Example for GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,55 @@
+name: "Run Tests"
+
+on: [ push ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    env:
+      WP_DB_HOST: 127.0.0.1
+      WP_DB_NAME: wp_phpunit_tests
+      WP_DB_USER: root
+      WP_DB_PASS: ""
+
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_DATABASE: wp_phpunit_tests
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ 8.0, 7.4, 5.6 ]
+        wordpress: [ 5.8.* ]
+
+    name: php${{ matrix.php }} - wp${{ matrix.wordpress }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          tools: wp
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer require --no-update --dev roots/wordpress:${{ matrix.wordpress }} wp-phpunit/wp-phpunit:${{ matrix.wordpress }}
+          [ ${{ matrix.php }} == 8 ] || composer install
+          # Temporary hack to allow installing PHPUnit 7 with PHP 8 until WP 5.9.
+          # as WP PHPUnit does not allow PHPUnit higher than 7 yet.
+          # See https://github.com/WordPress/wordpress-develop/commit/8def694fe4c5df95f8e20e40389faf9cb92b6dca
+          [ ${{ matrix.php }} != 8 ] || composer install --ignore-platform-reqs
+          composer show
+
+      - name: Execute tests
+        run: composer test

--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,10 @@
     },
     "scripts": {
         "test": "phpunit"
+    },
+    "config": {
+        "allow-plugins": {
+            "roots/wordpress-core-installer": true
+        }
     }
 }

--- a/tests/wp-config.php
+++ b/tests/wp-config.php
@@ -34,7 +34,7 @@ define( 'WP_DEBUG', true );
 define( 'DB_NAME'       , getenv( 'WP_DB_NAME' ) ?: 'wp_phpunit_tests' );
 define( 'DB_USER'       , getenv( 'WP_DB_USER' ) ?: 'root' );
 define( 'DB_PASSWORD'   , getenv( 'WP_DB_PASS' ) ?: '' );
-define( 'DB_HOST'       , 'localhost' );
+define( 'DB_HOST'       , getenv( 'WP_DB_HOST' ) ?: 'localhost' );
 define( 'DB_CHARSET'    , 'utf8' );
 define( 'DB_COLLATE'    , '' );
 


### PR DESCRIPTION
This `examle-plugin` does a great job of helping any WordPress plugin to get up and running on PHPUnit. Also, it has a `.travis.yml` example, which is nice! 

However, for my project, I usually go with GitHub Actions. When implementing it, I faced a few issues, so figured would be helpful for others to have a working example.  